### PR TITLE
added large, medium and small avatars 

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,3 +1,22 @@
+// Partysphere avatars
+.avatar-large {
+  width: 149px;
+  height: 149px;
+  border-radius: 50%;
+}
+.avatar-medium {
+  width: 83px;
+  height: 83px;
+  border-radius: 50%;
+}
+.avatar-small {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+}
+
+
+// Le Wagon avatars
 .avatar {
   width: 40px;
   border-radius: 50%;


### PR DESCRIPTION
Large, medium and small avatars work only thing we need is the Spotify profile picture (for the large avatar in the User Profile & medium avatar in Guest List) Small avatar is for the Playlist (Tracks) page, not sure if we want to use the track's album cover from Spotify or not sue the avatar at all and just display a "play" button.