### PR TITLE
STYLEFIX removed margin left on user avatar

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -1,6 +1,6 @@
-#centered {
-  margin-left: -22px; // take this out to center the profile picture
-}
+// #centered {
+//   margin-left: -22px; // take this out to center the profile picture
+// }
 
 
 // Partysphere User avatar


### PR DESCRIPTION
I commented out the css to give the user's profile photo on the profile page some margin left. This was only used for demo purposes.